### PR TITLE
Expose os/exec.Cmd.Env functionality

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -58,6 +58,7 @@ import (
 type Cmd struct {
 	Name   string
 	Args   []string
+	Env    []string
 	Stdout chan string // streaming STDOUT if enabled, else nil (see Options)
 	Stderr chan string // streaming STDERR if enabled, else nil (see Options)
 	*sync.Mutex
@@ -271,6 +272,10 @@ func (c *Cmd) run() {
 		cmd.Stdout = NewOutputStream(c.Stdout)
 		cmd.Stderr = NewOutputStream(c.Stderr)
 	}
+
+	// Set the runtime environment for the command as per os/exec.Cmd.  If Env
+	// is nil, use the current process' environment.
+	cmd.Env = c.Env
 
 	// //////////////////////////////////////////////////////////////////////
 	// Start command

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -951,3 +951,38 @@ TIMER:
 		t.Error(diff)
 	}
 }
+
+func TestCmdEnvOK(t *testing.T) {
+	now := time.Now().Unix()
+
+	p := cmd.NewCmd("env")
+	p.Env = []string{"FOO=foo"}
+	gotStatus := <-p.Start()
+	expectStatus := cmd.Status{
+		Cmd:      "env",
+		PID:      gotStatus.PID, // nondeterministic
+		Complete: true,
+		Exit:     0,
+		Error:    nil,
+		Runtime:  gotStatus.Runtime, // nondeterministic
+		Stdout:   []string{"FOO=foo"},
+		Stderr:   []string{},
+	}
+	if gotStatus.StartTs < now {
+		t.Error("StartTs < now")
+	}
+	if gotStatus.StopTs < gotStatus.StartTs {
+		t.Error("StopTs < StartTs")
+	}
+	gotStatus.StartTs = 0
+	gotStatus.StopTs = 0
+	if diffs := deep.Equal(gotStatus, expectStatus); diffs != nil {
+		t.Error(diffs)
+	}
+	if gotStatus.PID < 0 {
+		t.Errorf("got PID %d, expected non-zero", gotStatus.PID)
+	}
+	if gotStatus.Runtime < 0 {
+		t.Errorf("got runtime %f, expected non-zero", gotStatus.Runtime)
+	}
+}


### PR DESCRIPTION
Hi!  Thanks for starting this tool!  

We needed to expose the ability to set environment variables on the underlying Cmd object.  This PR contains the minimal set of changes we needed to get this to work and a basic test for this functionality.

As per the normal os/exec.Cmd, if the Env is nil (i.e.  not set) then the current process' environment will be used.

I didn't see any contributor guidelines, so this is best-effort -- please let me know if you need me to make any changes.