### PR TITLE
Implement Cmd.Clone()

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -155,6 +155,8 @@ func NewCmdOptions(options Options, name string, args ...string) *Cmd {
 
 // Clone clones a Cmd. All the options are transferred,
 // but the state of the original object is lost.
+// Cmd is one-use only, so if you need to re-start a Cmd,
+// you need to Clone it.
 func (c *Cmd) Clone() *Cmd {
 	clone := NewCmdOptions(
 		Options{

--- a/cmd.go
+++ b/cmd.go
@@ -154,7 +154,7 @@ func NewCmdOptions(options Options, name string, args ...string) *Cmd {
 }
 
 // Clone clones a Cmd. All the options are transferred,
-// but the state of the original object is lost.
+// but the internal state of the original object is lost.
 // Cmd is one-use only, so if you need to re-start a Cmd,
 // you need to Clone it.
 func (c *Cmd) Clone() *Cmd {
@@ -166,8 +166,6 @@ func (c *Cmd) Clone() *Cmd {
 		c.Name,
 		c.Args...,
 	)
-	clone.Lock()
-	defer clone.Unlock()
 	clone.Dir = c.Dir
 	clone.Env = c.Env
 	return clone

--- a/cmd.go
+++ b/cmd.go
@@ -153,6 +153,24 @@ func NewCmdOptions(options Options, name string, args ...string) *Cmd {
 	return out
 }
 
+// Clone clones a Cmd. All the options are transferred,
+// but the state of the original object is lost.
+func (c *Cmd) Clone() *Cmd {
+	clone := NewCmdOptions(
+		Options{
+			Buffered:  c.buffered,
+			Streaming: c.Stdout != nil,
+		},
+		c.Name,
+		c.Args...,
+	)
+	clone.Lock()
+	defer clone.Unlock()
+	clone.Dir = c.Dir
+	clone.Env = c.Env
+	return clone
+}
+
 // Start starts the command and immediately returns a channel that the caller
 // can use to receive the final Status of the command when it ends. The caller
 // can start the command and wait like,

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -47,6 +47,26 @@ func TestCmdOK(t *testing.T) {
 	}
 }
 
+func TestCmdClone(t *testing.T) {
+	opt := cmd.Options{
+		Buffered: true,
+	}
+	c1 := cmd.NewCmdOptions(opt, "ls")
+	c1.Dir = "/tmp/"
+	c1.Env = []string{"YES=please"}
+	c2 := c1.Clone()
+
+	if c1.Name != c2.Name {
+		t.Errorf("got Name %s, expecting %s", c2.Name, c1.Name)
+	}
+	if c1.Dir != c2.Dir {
+		t.Errorf("got Dir %s, expecting %s", c2.Dir, c1.Dir)
+	}
+	if diffs := deep.Equal(c1.Env, c2.Env); diffs != nil {
+		t.Error(diffs)
+	}
+}
+
 func TestCmdNonzeroExit(t *testing.T) {
 	p := cmd.NewCmd("false")
 	gotStatus := <-p.Start()


### PR DESCRIPTION
Implemented simple Clone as discussed in https://github.com/go-cmd/cmd/issues/33
