### PR TITLE
Implement a consistent state

### DIFF
--- a/cmd_test.go
+++ b/cmd_test.go
@@ -19,14 +19,13 @@ func TestCmdOK(t *testing.T) {
 	p := cmd.NewCmd("echo", "foo")
 	gotStatus := <-p.Start()
 	expectStatus := cmd.Status{
-		Cmd:      "echo",
-		PID:      gotStatus.PID, // nondeterministic
-		Complete: true,
-		Exit:     0,
-		Error:    nil,
-		Runtime:  gotStatus.Runtime, // nondeterministic
-		Stdout:   []string{"foo"},
-		Stderr:   []string{},
+		Cmd:     "echo",
+		PID:     gotStatus.PID, // nondeterministic
+		Exit:    0,
+		Error:   nil,
+		Runtime: gotStatus.Runtime, // nondeterministic
+		Stdout:  []string{"foo"},
+		Stderr:  []string{},
 	}
 	if gotStatus.StartTs < now {
 		t.Error("StartTs < now")
@@ -71,14 +70,13 @@ func TestCmdNonzeroExit(t *testing.T) {
 	p := cmd.NewCmd("false")
 	gotStatus := <-p.Start()
 	expectStatus := cmd.Status{
-		Cmd:      "false",
-		PID:      gotStatus.PID, // nondeterministic
-		Complete: true,
-		Exit:     1,
-		Error:    nil,
-		Runtime:  gotStatus.Runtime, // nondeterministic
-		Stdout:   []string{},
-		Stderr:   []string{},
+		Cmd:     "false",
+		PID:     gotStatus.PID, // nondeterministic
+		Exit:    1,
+		Error:   nil,
+		Runtime: gotStatus.Runtime, // nondeterministic
+		Stdout:  []string{},
+		Stderr:  []string{},
 	}
 	gotStatus.StartTs = 0
 	gotStatus.StopTs = 0
@@ -131,14 +129,13 @@ func TestCmdStop(t *testing.T) {
 	gotStatus.StopTs = 0
 
 	expectStatus := cmd.Status{
-		Cmd:      "./test/count-and-sleep",
-		PID:      gotStatus.PID,                    // nondeterministic
-		Complete: false,                            // signaled by Stop
-		Exit:     -1,                               // signaled by Stop
-		Error:    errors.New("signal: terminated"), // signaled by Stop
-		Runtime:  gotStatus.Runtime,                // nondeterministic
-		Stdout:   []string{"1"},
-		Stderr:   []string{},
+		Cmd:     "./test/count-and-sleep",
+		PID:     gotStatus.PID,                    // nondeterministic
+		Exit:    -1,                               // signaled by Stop
+		Error:   errors.New("signal: terminated"), // signaled by Stop
+		Runtime: gotStatus.Runtime,                // nondeterministic
+		Stdout:  []string{"1"},
+		Stderr:  []string{},
 	}
 	if diffs := deep.Equal(gotStatus, expectStatus); diffs != nil {
 		t.Error(diffs)
@@ -169,14 +166,13 @@ func TestCmdNotStarted(t *testing.T) {
 
 	gotStatus := p.Status()
 	expectStatus := cmd.Status{
-		Cmd:      "echo",
-		PID:      0,
-		Complete: false,
-		Exit:     -1,
-		Error:    nil,
-		Runtime:  0,
-		Stdout:   nil,
-		Stderr:   nil,
+		Cmd:     "echo",
+		PID:     0,
+		Exit:    -1,
+		Error:   nil,
+		Runtime: 0,
+		Stdout:  nil,
+		Stderr:  nil,
 	}
 	if diffs := deep.Equal(gotStatus, expectStatus); diffs != nil {
 		t.Error(diffs)
@@ -259,14 +255,13 @@ func TestCmdNotFound(t *testing.T) {
 	gotStatus.StartTs = 0
 	gotStatus.StopTs = 0
 	expectStatus := cmd.Status{
-		Cmd:      "cmd-does-not-exist",
-		PID:      0,
-		Complete: false,
-		Exit:     -1,
-		Error:    errors.New(`exec: "cmd-does-not-exist": executable file not found in $PATH`),
-		Runtime:  0,
-		Stdout:   nil,
-		Stderr:   nil,
+		Cmd:     "cmd-does-not-exist",
+		PID:     0,
+		Exit:    -1,
+		Error:   errors.New(`exec: "cmd-does-not-exist": executable file not found in $PATH`),
+		Runtime: 0,
+		Stdout:  []string{},
+		Stderr:  []string{},
 	}
 	if diffs := deep.Equal(gotStatus, expectStatus); diffs != nil {
 		t.Logf("%+v", gotStatus)
@@ -308,14 +303,13 @@ func TestCmdLost(t *testing.T) {
 	gotStatus.StopTs = 0
 
 	expectStatus := cmd.Status{
-		Cmd:      "./test/count-and-sleep",
-		PID:      s.PID,
-		Complete: false,
-		Exit:     -1,
-		Error:    errors.New("signal: killed"),
-		Runtime:  0,
-		Stdout:   []string{"1"},
-		Stderr:   []string{},
+		Cmd:     "./test/count-and-sleep",
+		PID:     s.PID,
+		Exit:    -1,
+		Error:   errors.New("signal: killed"),
+		Runtime: 0,
+		Stdout:  []string{"1"},
+		Stderr:  []string{},
 	}
 	if diffs := deep.Equal(gotStatus, expectStatus); diffs != nil {
 		t.Logf("%+v\n", gotStatus)
@@ -979,14 +973,13 @@ func TestCmdEnvOK(t *testing.T) {
 	p.Env = []string{"FOO=foo"}
 	gotStatus := <-p.Start()
 	expectStatus := cmd.Status{
-		Cmd:      "env",
-		PID:      gotStatus.PID, // nondeterministic
-		Complete: true,
-		Exit:     0,
-		Error:    nil,
-		Runtime:  gotStatus.Runtime, // nondeterministic
-		Stdout:   []string{"FOO=foo"},
-		Stderr:   []string{},
+		Cmd:     "env",
+		PID:     gotStatus.PID, // nondeterministic
+		Exit:    0,
+		Error:   nil,
+		Runtime: gotStatus.Runtime, // nondeterministic
+		Stdout:  []string{"FOO=foo"},
+		Stderr:  []string{},
 	}
 	if gotStatus.StartTs < now {
 		t.Error("StartTs < now")

--- a/state.go
+++ b/state.go
@@ -1,0 +1,35 @@
+package cmd
+
+const (
+	INITIAL = iota
+	STARTING
+	RUNNING
+	STOPPING
+	INTERRUPT // final state (used when stopped or signaled)
+	FINISHED  // final state (used in cas of a natural exit)
+	FATAL     // final state (used in case of error while starting)
+)
+
+// CmdState represents all Cmd states
+type CmdState uint8
+
+func (p CmdState) String() string {
+	switch p {
+	case INITIAL:
+		return "initial"
+	case STARTING:
+		return "starting"
+	case RUNNING:
+		return "running"
+	case STOPPING:
+		return "stopping"
+	case INTERRUPT:
+		return "interrupted"
+	case FINISHED:
+		return "finished"
+	case FATAL:
+		return "fatal"
+	default:
+		return "unknown"
+	}
+}

--- a/state_test.go
+++ b/state_test.go
@@ -9,7 +9,7 @@ import (
 func TestState1(t *testing.T) {
 	var s cmd.CmdState
 
-	s = 0
+	s = cmd.INITIAL
 	if s.String() != "initial" {
 		t.Errorf("got State %s, expecting %s", s.String(), "initial")
 	}
@@ -17,6 +17,11 @@ func TestState1(t *testing.T) {
 	s = cmd.STARTING
 	if s.String() != "starting" {
 		t.Errorf("got State %s, expecting %s", s.String(), "starting")
+	}
+
+	s = cmd.RUNNING
+	if s.String() != "running" {
+		t.Errorf("got State %s, expecting %s", s.String(), "running")
 	}
 
 	s = cmd.STOPPING
@@ -32,6 +37,20 @@ func TestState1(t *testing.T) {
 	s = cmd.FINISHED
 	if s.String() != "finished" {
 		t.Errorf("got State %s, expecting %s", s.String(), "finished")
+	}
+
+	s = cmd.FATAL
+	if s.String() != "fatal" {
+		t.Errorf("got State %s, expecting %s", s.String(), "fatal")
+	}
+}
+
+func TestState2(t *testing.T) {
+	var s cmd.CmdState
+
+	s = 0
+	if s.String() != "initial" {
+		t.Errorf("got State %s, expecting %s", s.String(), "initial")
 	}
 
 	s = 99

--- a/state_test.go
+++ b/state_test.go
@@ -1,0 +1,41 @@
+package cmd_test
+
+import (
+	"testing"
+
+	"github.com/go-cmd/cmd"
+)
+
+func TestState1(t *testing.T) {
+	var s cmd.CmdState
+
+	s = 0
+	if s.String() != "initial" {
+		t.Errorf("got State %s, expecting %s", s.String(), "initial")
+	}
+
+	s = cmd.STARTING
+	if s.String() != "starting" {
+		t.Errorf("got State %s, expecting %s", s.String(), "starting")
+	}
+
+	s = cmd.STOPPING
+	if s.String() != "stopping" {
+		t.Errorf("got State %s, expecting %s", s.String(), "stopping")
+	}
+
+	s = cmd.INTERRUPT
+	if s.String() != "interrupted" {
+		t.Errorf("got State %s, expecting %s", s.String(), "interrupted")
+	}
+
+	s = cmd.FINISHED
+	if s.String() != "finished" {
+		t.Errorf("got State %s, expecting %s", s.String(), "finished")
+	}
+
+	s = 99
+	if s.String() != "unknown" {
+		t.Errorf("got State %s, expecting %s", s.String(), "unknown")
+	}
+}


### PR DESCRIPTION
This PR implements a consistent state for Cmd.

* if the respective command crashes on start, the states will be: initial, starting, fatal
* it it's a natural exit, the states will be: initial, starting, running, finished
* if it's Stopped after start, the states will be: initial, starting, running, stopping, interrupt
* there's also the case when it's killed externally, so in that case the "stopping" state will not be triggered
* the fatal, finished and interrupt states are final and the command can never be started again. This is where Clone() function is useful, so you can start a fresh Cmd instance.

Human readable description of the changes:

* after this PR gets merged, I'll create a git tag, probably "v1.1" because **this is a breaking change** - because of the Cmd and Status struct changes
* removed started, stopped, done, final from "Cmd" struct and replaced with `State` (is it a good idea to make the State a public variable ?)
* removed `Complete` variable from "Status" struct (is it a good idea to include the State instead ? In case it's a private variable, it would make sense)
* added private `setState` and public `IsInitialState` and `IsFinalState` because they are relevant to be public.
