### PR TITLE
Close streaming output channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ os:
   - windows
 
 go:
+  - "1.12"
   - "1.13"
 
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# go-cmd/cmd Changelog
+
+## v1.2
+
+### v1.2.0 (2020-01-26)
+
+* Changed streaming output: channels are closed after command stops (issue #26)
+* Updated examples/blocking-streaming
+
+## v1.1
+
+### v1.1.0 (2019-11-24)
+
+* Added support for Windows (PR #24) (@hfrappier, et al.)
+
+## v1.0
+
+### v1.0.6 (2019-09-30)
+
+* Use go mod (PR #37) (@akkumar)
+
+### v1.0.5 (2019-07-20)
+
+* Fixed typo in README (PR #28) (@alokrajiv)
+* Added `Cmd.Clone()` (PR #35) (@croqaz)
+* Code cleanup (PR #34) (@croqaz)
+
+### v1.0.4 (2018-11-22)
+
+* Fixed no output: Buffered=false, Streaming=false
+* Added `Cmd.Dir` to set `os/exec.Cmd.Dir` (PR #25) (@tkschmidt)
+
+### v1.0.3 (2018-05-13)
+
+* Added `Cmd.Env` to set `os/exec.Cmd.Env` (PR #14) (@robothor)
+
+### v1.0.2 (2018-04-28)
+
+* Changed `Running()` to `Done() <-chan struct{}` to match `Context.Done()` and support multiple waiters (PR #13)
+
+### v1.0.1 (2018-04-22)
+
+* Fixed errors in example code (PR #9) (@anshap1719)
+* Added NewCmdOptions, Options, OutputBuffer, and OutputStream
+* Added example code
+
+### v1.0.0 (2017-03-22)
+
+* First release.

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -265,7 +265,7 @@ func TestCmdNotFound(t *testing.T) {
 		PID:      0,
 		Complete: false,
 		Exit:     -1,
-		Error:    errors.New(`exec: "cmd-does-not-exist": executable file not found in $PATH`),
+		Error:    &exec.Error{Name: "cmd-does-not-exist", Err: errors.New(`executable file not found in $PATH`)},
 		Runtime:  0,
 		Stdout:   nil,
 		Stderr:   nil,

--- a/examples/blocking-streaming/print-some-lines
+++ b/examples/blocking-streaming/print-some-lines
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This script just prints some lines to simulate random command out
+# that is streamed and printed by main.go.
+
+for i in 1 2 3 4 5; do
+  echo "Line $i"
+  sleep 0.2
+done
+
+echo "One more..."
+sleep 1
+
+echo "Last line"

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/go-cmd/cmd
 
 go 1.13
 
-require github.com/go-test/deep v1.0.1
+require github.com/go-test/deep v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/go-test/deep v1.0.1 h1:UQhStjbkDClarlmv0am7OXXO4/GaPdCGiUiMTvi28sg=
 github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/go-test/deep v1.0.5 h1:AKODKU3pDH1RzZzm6YZu77YWtEAq6uh1rLIAQlay2qc=
+github.com/go-test/deep v1.0.5/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=


### PR DESCRIPTION
* Close streaming output chans (`cmd.Stdout`, `cmd.Stderr`) (issue #26)
* Refactor NewCmd
* Update blocking-streaming example
* Test on go1.12 and 1.13
