### PR TITLE
Export used CommandExecutor for testing DI

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -289,6 +289,7 @@ func (c *Cmd) Done() <-chan struct{} {
 }
 
 // --------------------------------------------------------------------------
+var CommandExecutor = exec.Command
 
 func (c *Cmd) run() {
 	defer func() {
@@ -299,7 +300,7 @@ func (c *Cmd) run() {
 	// //////////////////////////////////////////////////////////////////////
 	// Setup command
 	// //////////////////////////////////////////////////////////////////////
-	cmd := exec.Command(c.Name, c.Args...)
+	cmd := CommandExecutor(c.Name, c.Args...)
 
 	// Platform-specific SysProcAttr management
 	setProcessGroupID(cmd)


### PR DESCRIPTION
Export the command executor, so we can mock all the executed commands for testing. 

Explanation: https://npf.io/2015/06/testing-exec-command/

```golang
func fakeExecCommand(command string, args ...string) *exec.Cmd {
	cs := []string{"-test.run=TestHelperProcess", "--", command}
	argWithEnv := append(args, "GO_TEST_PROCESS")
	cs = append(cs, argWithEnv...)
	cmd := exec.Command(os.Args[0], cs...)
	return cmd
}

const commandMock = "OutputMock"

func TestHelperProcess(t *testing.T) {
	if os.Args[len(os.Args)-1] != "GO_TEST_PROCESS" {
		return
	}

	defer os.Exit(0)
	fmt.Fprintf(os.Stdout, "%s", dockerRunResult)
}

It("new test", func() {
	cmd.ComandExecuter = fakeExecCommand
	defer func() { cmd.ComandExecuter = exec.Command }()

        ... testing here.....
})
```

Issue: https://github.com/go-cmd/cmd/issues/45