### PR TITLE
fix: last line is never sent

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -326,6 +326,8 @@ func (c *Cmd) run() {
 	// who's waiting for us to close them.
 	if c.stdoutStream != nil {
 		defer func() {
+			c.stdoutStream.Flush()
+			c.stderrStream.Flush()
 			// exec.Cmd.Wait has already waited for all output:
 			//   Otherwise, during the execution of the command a separate goroutine
 			//   reads from the process over a pipe and delivers that data to the
@@ -634,4 +636,12 @@ func (rw *OutputStream) Lines() <-chan string {
 func (rw *OutputStream) SetLineBufferSize(n int) {
 	rw.bufSize = n
 	rw.buf = make([]byte, rw.bufSize)
+}
+
+// Flush empties the buffer of its last line.
+func (rw *OutputStream) Flush() {
+	if rw.lastChar > 0 {
+		line := string(rw.buf[0:rw.lastChar])
+		rw.streamChan <- line
+	}
 }

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -559,7 +559,7 @@ func TestStreamingMultipleLines(t *testing.T) {
 	}
 
 	// Write two short lines
-	input := "foo\nbar\n"
+	input := "foo\nbar"
 	n, err := out.Write([]byte(input))
 	if n != len(input) {
 		t.Errorf("Write n = %d, expected %d", n, len(input))
@@ -580,6 +580,8 @@ func TestStreamingMultipleLines(t *testing.T) {
 	if gotLine != "foo" {
 		t.Errorf("got line: '%s', expected 'foo'", gotLine)
 	}
+
+	out.Flush()
 
 	// Get next line
 	select {


### PR DESCRIPTION
I've been experimenting with the streaming option and it seems that it misses the last line if that one isn't terminated by a carriage return.