### PR TITLE
Add support for sending arbitrary signals to a process

### DIFF
--- a/cmd_darwin.go
+++ b/cmd_darwin.go
@@ -5,11 +5,8 @@ import (
 	"syscall"
 )
 
-func terminateProcess(pid int) error {
-	// Signal the process group (-pid), not just the process, so that the process
-	// and all its children are signaled. Else, child procs can keep running and
-	// keep the stdout/stderr fd open and cause cmd.Wait to hang.
-	return syscall.Kill(-pid, syscall.SIGTERM)
+func signalProcess(pid int, sig syscall.Signal) error {
+	return syscall.Kill(pid, sig)
 }
 
 func setProcessGroupID(cmd *exec.Cmd) {

--- a/cmd_freebsd.go
+++ b/cmd_freebsd.go
@@ -5,11 +5,8 @@ import (
 	"syscall"
 )
 
-func terminateProcess(pid int) error {
-	// Signal the process group (-pid), not just the process, so that the process
-	// and all its children are signaled. Else, child procs can keep running and
-	// keep the stdout/stderr fd open and cause cmd.Wait to hang.
-	return syscall.Kill(-pid, syscall.SIGTERM)
+func signalProcess(pid int, sig syscall.Signal) error {
+	return syscall.Kill(pid, sig)
 }
 
 func setProcessGroupID(cmd *exec.Cmd) {

--- a/cmd_linux.go
+++ b/cmd_linux.go
@@ -5,11 +5,8 @@ import (
 	"syscall"
 )
 
-func terminateProcess(pid int) error {
-	// Signal the process group (-pid), not just the process, so that the process
-	// and all its children are signaled. Else, child procs can keep running and
-	// keep the stdout/stderr fd open and cause cmd.Wait to hang.
-	return syscall.Kill(-pid, syscall.SIGTERM)
+func signalProcess(pid int, sig syscall.Signal) error {
+	return syscall.Kill(pid, sig)
 }
 
 func setProcessGroupID(cmd *exec.Cmd) {

--- a/cmd_windows.go
+++ b/cmd_windows.go
@@ -6,16 +6,14 @@ import (
 	"syscall"
 )
 
-// Stop stops the command by sending its process group a SIGTERM signal.
-// Stop is idempotent. An error should only be returned in the rare case that
-// Stop is called immediately after the command ends but before Start can
-// update its internal state.
-func terminateProcess(pid int) error {
+// Send the given signal to the process, returns an error if the process isn't
+// running.
+func signalProcess(pid int, sig syscall.Signal) error {
 	p, err := os.FindProcess(pid)
 	if err != nil {
 		return err
 	}
-	return p.Kill()
+	return p.Signal(sig)
 }
 
 func setProcessGroupID(cmd *exec.Cmd) {

--- a/cmd_windows_internal_test.go
+++ b/cmd_windows_internal_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestTerminateProcess(t *testing.T) {
-	err := terminateProcess(123)
+	err := signalProcess(123, syscall.SIGTERM)
 	if err == nil {
 		t.Error("no error, expected one on terminating nonexisting PID")
 	}


### PR DESCRIPTION
This adds a public method, cmd.SendSignal, that allows sending a signal
to a process and, optionally, to the entire process group.

Internally, terminateProcess is replaced by signalProcess.

